### PR TITLE
Ruby dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'sass'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sass (3.3.14)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sass


### PR DESCRIPTION
Adds a `Gemfile` for Sass. If we're going to keep PHP and Node dependencies locked, it makes sense to lock the Ruby dependencies, too.
